### PR TITLE
docs: expand README and add architecture overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,74 +1,59 @@
 # Daytrading (CoinEx) — vectorbt + CCXT
 
+A lightweight research scaffold for exploring crypto trading strategies on the CoinEx exchange. Data is pulled with [ccxt](https://github.com/ccxt/ccxt) and strategies are backtested using [vectorbt](https://vectorbt.pro/).
+
+## Project structure
+
+| Path | Description |
+| ---- | ----------- |
+| `src/data/fetch_coinex.py` | Fetch OHLCV data and store it as Parquet (resumes from previous runs). |
+| `src/backtest/run_backtest.py` | Run grid backtests for EMA‑cross and Bollinger‑Band mean‑reversion strategies. |
+| `src/analysis/advanced_report.py` | Generate KPIs and Plotly charts from a backtest run directory. |
+| `src/signals/make_signals.py` | Build entry/exit signal CSVs for a symbol and strategy. |
+| `src/exec/paper.py` | Simple paper‑trading simulator that replays signal CSVs. |
+| `src/strategies/` | Strategy helpers used for building signals. |
+| `src/utils/` | Configuration and I/O utilities. |
+| `tests/` | Unit tests and smoke checks. |
+
+More details can be found in [docs/architecture.md](docs/architecture.md).
+
 ## Quickstart
 
-1) python -m venv .venv && source .venv/bin/activate  # Windows: .venv\Scripts\activate
-2) pip install -r requirements.txt
-3) cp .env.example .env  # (optional; only needed for private endpoints)
-4) Edit config/config.yaml (symbols, timeframe, start_days)
-5) Fetch data:
-   python src/data/fetch_coinex.py --cfg config/config.yaml
-6) Run backtest (EMA Cross example):
-   python src/backtest/run_backtest.py --cfg config/config.yaml --strategy ema_cross
-7) See outputs in out/backtests/<run_id>/ (summary.csv, equity.png)
-
-## Additional Development Info
-
-### Pre-commit Setup
-
-Install pre-commit and set up hooks:
-
-```sh
-pip install pre-commit
-pre-commit install
-pre-commit run --all-files
-```
-
-Hooks: ruff (lint/format), pyupgrade (syntax upgrade)
-
-### Type checking
-
-Run mypy:
-
-```sh
-mypy .
-```
-
-### CI
-
-GitHub Actions workflow: `.github/workflows/ci.yml` (lint + smoke backtest)
-
-## Config schema
-
-See `src/utils/config.py` for Pydantic model. Edit `config/config.yaml` for symbols, timeframe, strategy params, etc.
-
-## Output paths
-
-- Backtests: `out/backtests/<run_id>/`
-- Logs: `logs/`
-- Parquet data: `data/parquet/`
-
-## Known limitations
-
-- No Docker support (out of scope)
-- Paper trading is stub only (no live orders)
-- Only EMA/BB strategies implemented
+1. `python -m venv .venv && source .venv/bin/activate`  
+   *(Windows: `.venv\Scripts\activate`)*
+2. `pip install -r requirements.txt`
+3. `cp .env.example .env` *(optional; only needed for private endpoints)*
+4. Edit `config/config.yaml` (symbols, timeframe, strategy parameters)
+5. Fetch data:  `python src/data/fetch_coinex.py --cfg config/config.yaml`
+6. Run backtest: `python src/backtest/run_backtest.py --cfg config/config.yaml --strategy ema_cross`
+7. See outputs in `out/backtests/<run_id>/` (CSV summary, equity chart, etc.)
 
 ## Development
 
 ### Pre-commit hooks
 
-Install pre-commit and set up hooks:
-
 ```sh
 pip install pre-commit
 pre-commit install
 pre-commit run --all-files
 ```
 
-Hooks: ruff (lint/format), pyupgrade (syntax upgrade)
+### Type checking
+
+```sh
+mypy .
+```
+
+### Tests
+
+```sh
+pytest
+```
 
 ## Notes
 
-- This scaffold uses vectorbt for fast research/backtests and ccxt for data.
-- Execution (paper/live) is out-of-scope here; we can add a CCXT bridge later.
+- Built for quick experimentation; Docker and live trading are out of scope.
+- Output directories:
+  - Backtests → `out/backtests/<run_id>/`
+  - Logs → `logs/`
+  - Price data → `data/parquet/`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,51 @@
+# Project Architecture
+
+This document outlines the major components of this crypto trading research scaffold and how they fit together.
+
+## Data fetching (`src/data`)
+
+### `fetch_coinex.py`
+Fetches historical OHLCV data from the CoinEx exchange via **ccxt**. It resumes from existing Parquet files, respects the exchange rate limit, performs basic integrity checks, and stores the result in `data/parquet/` (optionally also writes raw CSVs). Structured logs are written under `logs/`.
+
+## Backtesting (`src/backtest`)
+
+### `run_backtest.py`
+Runs vectorised grid backtests for the built‑in strategies. Features include:
+- EMA cross and Bollinger Bands mean reversion strategies
+- fees, slippage, stop‑loss and take‑profit handling
+- optional cap on trades per day
+- CSV export of grid results, parameter JSON, simple HTML report, equity chart and a pickled `Portfolio` for the best Sharpe ratio
+
+## Analysis (`src/analysis`)
+
+### `advanced_report.py`
+Generates additional KPIs and plots from a backtest output directory. It loads the saved portfolio, exports equity/returns/drawdown/trades series, and saves Plotly charts (orders, PnL distribution, monthly returns, rolling Sharpe, underwater, turnover) as PNG/HTML alongside a small HTML index.
+
+## Signal generation (`src/signals`)
+
+### `make_signals.py`
+Builds entry/exit signal CSV files for a single symbol and strategy using stored price data. The signals are aligned with price, normalised to a standard schema and saved in `out/signals/` for use by the paper trading simulator or other tooling.
+
+## Execution (`src/exec`)
+
+### `paper.py`
+A lightweight paper trading simulator that consumes a signals CSV and the project configuration. It applies fees, slippage and an optional daily loss limit, tracks cash, and outputs a trades CSV together with structured logs.
+
+## Strategies (`src/strategies`)
+
+- `ema_cross.py` – constructs moving‑average crossover entry/exit signals.
+- `bb_meanrev.py` – constructs Bollinger Bands mean‑reversion signals.
+
+## Utilities (`src/utils`)
+
+- `config.py` – Pydantic models describing the configuration schema (symbols, timeframe, strategy parameters, etc.).
+- `io.py` – helper for loading YAML configs with helpful error messages.
+
+## Other directories
+
+- `config/` – sample configuration files.
+- `data/` – raw CSV and Parquet price data.
+- `logs/` – runtime logs.
+- `tests/` – unit tests for I/O, strategies and smoke backtests.
+- `notebooks/` – exploratory research notebooks.
+


### PR DESCRIPTION
## Summary
- document project structure and quickstart in an expanded README
- add `docs/architecture.md` describing all modules and directories

## Testing
- `pre-commit run --files README.md docs/architecture.md`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'vectorbt')*

------
https://chatgpt.com/codex/tasks/task_e_689dab0f61e483298bb03f682cb0a5cf