### PR TITLE
Add trade guard settings to config

### DIFF
--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 from pydantic import BaseModel, Field, field_validator
 from typing import Literal
 
-Timeframe = Literal["1m","3m","5m","15m","30m","1h","4h","1d"]
+Timeframe = Literal["1m", "3m", "5m", "15m", "30m", "1h", "4h", "1d"]
+
 
 class StrategyEMA(BaseModel):
     fast_windows: list[int]
@@ -9,15 +12,18 @@ class StrategyEMA(BaseModel):
     sl_stop_pct: float = Field(ge=0, le=0.5)
     tp_stop_pct: float = Field(ge=0, le=1.0)
 
+
 class StrategyBB(BaseModel):
     window_list: list[int]
     k_list: list[float]
     sl_stop_pct: float = Field(ge=0, le=0.5)
     tp_stop_pct: float = Field(ge=0, le=1.0)
 
+
 class Strategies(BaseModel):
     ema_cross: StrategyEMA
     bb_meanrev: StrategyBB
+
 
 class Config(BaseModel):
     symbols: list[str]
@@ -27,10 +33,12 @@ class Config(BaseModel):
     fees_bps: float = Field(ge=0, le=1000)
     slippage_bps: float = Field(ge=0, le=100)
     init_cash: float = Field(gt=0)
+    daily_loss_limit_pct: float | None = Field(default=None, ge=0, le=1.0)
+    max_trades_per_day: int | None = Field(default=None, ge=1, le=1000)
     strategies: Strategies
 
-    @field_validator('symbols')
+    @field_validator("symbols")
     def symbols_not_empty(cls, v):
         if not v:
-            raise ValueError('symbols list must not be empty')
+            raise ValueError("symbols list must not be empty")
         return v

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,0 +1,51 @@
+import pytest
+from src.utils.config import Config
+
+
+def base_cfg():
+    return {
+        "symbols": ["BTC/USDT"],
+        "timeframe": "1h",
+        "start_days": 1,
+        "rate_limit_ms": 200,
+        "fees_bps": 10,
+        "slippage_bps": 2,
+        "init_cash": 8000,
+        "strategies": {
+            "ema_cross": {
+                "fast_windows": [10],
+                "slow_windows": [30],
+                "sl_stop_pct": 0.02,
+                "tp_stop_pct": 0.04,
+            },
+            "bb_meanrev": {
+                "window_list": [20],
+                "k_list": [2.0],
+                "sl_stop_pct": 0.015,
+                "tp_stop_pct": 0.02,
+            },
+        },
+    }
+
+
+def test_valid_limits():
+    cfg = base_cfg()
+    cfg["daily_loss_limit_pct"] = 0.5
+    cfg["max_trades_per_day"] = 50
+    parsed = Config.model_validate(cfg)
+    assert parsed.daily_loss_limit_pct == 0.5
+    assert parsed.max_trades_per_day == 50
+
+
+def test_invalid_daily_loss_limit():
+    cfg = base_cfg()
+    cfg["daily_loss_limit_pct"] = 1.5
+    with pytest.raises(Exception):
+        Config.model_validate(cfg)
+
+
+def test_invalid_max_trades():
+    cfg = base_cfg()
+    cfg["max_trades_per_day"] = 0
+    with pytest.raises(Exception):
+        Config.model_validate(cfg)


### PR DESCRIPTION
## Summary
- extend Config model with `daily_loss_limit_pct` and `max_trades_per_day`
- load new limits in backtest, event runner, and CLI utilities
- test config validation for trade-guard bounds

## Testing
- `pre-commit run --files src/utils/config.py src/backtest/run_backtest.py src/scripts/run_event_from_config.py src/exec/paper.py tests/test_config_validation.py`
- `pytest`
- `python - <<'PY'
from src.utils.io import load_yaml
from src.utils.config import Config
cfg=Config.model_validate(load_yaml('config/config.yaml'))
print('ok', cfg.max_trades_per_day, cfg.daily_loss_limit_pct)
PY`

------
https://chatgpt.com/codex/tasks/task_e_689dbf88fa1083298696930d87f1d461