### PR TITLE
Use validated config in event script and test invalid configs

### DIFF
--- a/src/scripts/run_event_from_config.py
+++ b/src/scripts/run_event_from_config.py
@@ -51,8 +51,7 @@ def main():
     ap.add_argument("--out", default="out/event_backtests", help="Output root folder")
     args = ap.parse_args()
 
-    raw = load_yaml(args.cfg)
-    cfg = Config.model_validate(raw)
+    cfg = Config.model_validate(load_yaml(args.cfg))
 
     symbols = cfg.symbols
     timeframe = cfg.timeframe
@@ -61,7 +60,7 @@ def main():
     init_cash = float(cfg.init_cash)
     daily_loss_limit_pct = cfg.daily_loss_limit_pct
     max_trades_per_day = cfg.max_trades_per_day
-    risk_pct = float(raw.get("risk_pct_per_trade", 0.01))  # optional in YAML
+    risk_pct = float(cfg.risk_pct_per_trade)
 
     strat_cfg = cfg.strategies.ema_cross
     fast_list = list(strat_cfg.fast_windows)
@@ -163,7 +162,7 @@ def main():
         "run_id": run_id,
         "timeframe": timeframe,
         "symbols": symbols,
-        "config_used": raw,
+        "config_used": cfg.model_dump(),
     }
     (outdir / "params.json").write_text(json.dumps(params, indent=2), encoding="utf-8")
 

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -33,6 +33,7 @@ class Config(BaseModel):
     fees_bps: float = Field(ge=0, le=1000)
     slippage_bps: float = Field(ge=0, le=100)
     init_cash: float = Field(gt=0)
+    risk_pct_per_trade: float = Field(default=0.01, ge=0, le=1.0)
     daily_loss_limit_pct: float | None = Field(default=None, ge=0, le=1.0)
     max_trades_per_day: int | None = Field(default=None, ge=1, le=1000)
     strategies: Strategies

--- a/tests/test_run_event_from_config.py
+++ b/tests/test_run_event_from_config.py
@@ -1,0 +1,50 @@
+import subprocess
+import sys
+from pathlib import Path
+import textwrap
+import pytest
+
+
+def test_invalid_config_raises(tmp_path):
+    cfg_path = tmp_path / "bad.yml"
+    cfg_path.write_text(
+        textwrap.dedent(
+            """
+            symbols: []
+            timeframe: 1h
+            start_days: 1
+            rate_limit_ms: 200
+            fees_bps: 10
+            slippage_bps: 2
+            init_cash: 8000
+            strategies:
+              ema_cross:
+                fast_windows: [10]
+                slow_windows: [30]
+                sl_stop_pct: 0.02
+                tp_stop_pct: 0.04
+              bb_meanrev:
+                window_list: [20]
+                k_list: [2.0]
+                sl_stop_pct: 0.015
+                tp_stop_pct: 0.02
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "src.scripts.run_event_from_config",
+        "--cfg",
+        str(cfg_path),
+    ]
+    with pytest.raises(subprocess.CalledProcessError):
+        subprocess.run(
+            cmd,
+            check=True,
+            cwd=Path(__file__).resolve().parents[1],
+            capture_output=True,
+            text=True,
+        )


### PR DESCRIPTION
## Summary
- Parse event config with `load_yaml` and `Config.model_validate`
- Access script settings via the validated `Config` object
- Validate `risk_pct_per_trade` via `Config`
- Add smoke test to ensure invalid configs fail fast

## Testing
- `pre-commit run --files src/scripts/run_event_from_config.py src/utils/config.py tests/test_run_event_from_config.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689dc26d04048329b02b716e19675219