### PR TITLE
Move Streamlit dashboard under scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A lightweight research scaffold for exploring crypto trading strategies on the C
 | `src/analysis/advanced_report.py` | Generate KPIs and Plotly charts from a backtest run directory. |
 | `src/signals/make_signals.py` | Build entry/exit signal CSVs for a symbol and strategy. |
 | `src/exec/paper.py` | Simple paper‑trading simulator that replays signal CSVs. |
+| `src/scripts/dashboard.py` | Streamlit dashboard for exploring backtest runs. |
 | `src/strategies/` | Strategy helpers used for building signals. |
 | `src/utils/` | Configuration and I/O utilities. |
 | `tests/` | Unit tests and smoke checks. |
@@ -27,6 +28,7 @@ More details can be found in [docs/architecture.md](docs/architecture.md).
 5. Fetch data:  `python src/data/fetch_coinex.py --cfg config/config.yaml`
 6. Run backtest: `python src/backtest/run_backtest.py --cfg config/config.yaml --strategy ema_cross`
 7. See outputs in `out/backtests/<run_id>/` (CSV summary, equity chart, etc.)
+8. Launch dashboard (from project root): `streamlit run src/scripts/dashboard.py`
 
 ## Development
 

--- a/src/scripts/dashboard.py
+++ b/src/scripts/dashboard.py
@@ -19,7 +19,8 @@ import vectorbt as vbt
 # -----------------------------------------------------------
 # Configs
 # -----------------------------------------------------------
-BACKTEST_ROOT = Path("out/backtests").resolve()
+# Resolve repository root so dashboard works regardless of working directory
+BACKTEST_ROOT = Path(__file__).resolve().parents[2] / "out" / "backtests"
 
 
 # -----------------------------------------------------------


### PR DESCRIPTION
## Summary
- relocate `dashboard.py` into `src/scripts`
- adjust dashboard path handling for new location
- document dashboard usage and location in README

## Testing
- `pytest`
- `streamlit run src/scripts/dashboard.py --server.headless true --server.port 8501`


------
https://chatgpt.com/codex/tasks/task_e_689dc7d3ae508329adb6f6bd4d4c71ca