### PR TITLE
Add config and event backtest tests

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,65 @@
+import pytest
+from pydantic import ValidationError
+from src.utils.config import Config
+
+
+def base_cfg():
+    return {
+        "symbols": ["BTC/USDT"],
+        "timeframe": "1h",
+        "start_days": 1,
+        "rate_limit_ms": 200,
+        "fees_bps": 10,
+        "slippage_bps": 2,
+        "init_cash": 8000,
+        "strategies": {
+            "ema_cross": {
+                "fast_windows": [10],
+                "slow_windows": [30],
+                "sl_stop_pct": 0.02,
+                "tp_stop_pct": 0.04,
+            },
+            "bb_meanrev": {
+                "window_list": [20],
+                "k_list": [2.0],
+                "sl_stop_pct": 0.015,
+                "tp_stop_pct": 0.02,
+            },
+        },
+    }
+
+
+def test_required_fields():
+    required = [
+        "symbols",
+        "timeframe",
+        "start_days",
+        "rate_limit_ms",
+        "fees_bps",
+        "slippage_bps",
+        "init_cash",
+        "strategies",
+    ]
+    for field in required:
+        cfg = base_cfg()
+        cfg.pop(field)
+        with pytest.raises(ValidationError):
+            Config.model_validate(cfg)
+
+
+@pytest.mark.parametrize(
+    "field,bad",
+    [
+        ("start_days", 0),
+        ("rate_limit_ms", -1),
+        ("fees_bps", -5),
+        ("slippage_bps", 200),
+        ("init_cash", -100),
+        ("symbols", []),
+    ],
+)
+def test_invalid_values(field, bad):
+    cfg = base_cfg()
+    cfg[field] = bad
+    with pytest.raises(Exception):
+        Config.model_validate(cfg)

--- a/tests/test_event_smoke.py
+++ b/tests/test_event_smoke.py
@@ -1,0 +1,40 @@
+import numpy as np
+import pandas as pd
+from pathlib import Path
+
+from src.engine.event_backtester import EventBacktester
+
+
+def test_event_smoke(tmp_path: Path):
+    ts = pd.date_range("2020-01-01", periods=5, freq="1h", tz="UTC")
+    price = np.linspace(100, 110, 5)
+    df = pd.DataFrame(
+        {
+            "open": price,
+            "high": price + 2,
+            "low": price - 2,
+            "close": price + 1,
+        },
+        index=ts,
+    )
+
+    entries = pd.Series([True, False, False, True, False], index=ts)
+    exits = pd.Series([False, False, True, False, False], index=ts)
+
+    bt = EventBacktester(
+        df=df,
+        entries=entries,
+        exits=exits,
+        init_cash=1000,
+        fees_bps=10,
+        slippage_bps=1,
+        risk_pct_per_trade=0.1,
+        stop_mode="percent",
+        sl_pct=0.01,
+        tp_pct=0.02,
+    )
+    bt.run()
+    bt.save_outputs(tmp_path)
+
+    assert (tmp_path / "trades.csv").exists()
+    assert (tmp_path / "summary.json").exists()


### PR DESCRIPTION
## Summary
- add configuration validation tests for required fields and invalid values
- add event-driven backtest smoke test verifying output artifacts

## Testing
- `pre-commit run --files tests/test_config.py tests/test_event_smoke.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689dcbc9407483298de4f731eba4d4bc